### PR TITLE
[FEAT] check extra fields during initialization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TethysChlorisCore"
 uuid = "c22758e7-e854-5bdb-8df2-7602c47a9d98"
 authors = ["Hugo Solleder <hugo.solleder@epfl.ch>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ CurrentModule = TethysChlorisCore
 
 # TethysChlorisCore
 
-Welcome to the documentation for [TethysChlorisCore](https://github.com/EPFL-ENAC/TethysChlorisCore.jl). This package aims to facilitate the use of the Tethys-Chloris model by centralized shared utilities and types that are used by the Tethys-Chloris model and its extensions.
+Welcome to the documentation for [TethysChlorisCore](https://github.com/EPFL-ENAC/TethysChlorisCore.jl). This package aims to facilitate the use of the Tethys-Chloris model by centralizing shared utilities and types that are used by the Tethys-Chloris model and its extensions.
 
 ## Contributors
 

--- a/src/TethysChlorisCore.jl
+++ b/src/TethysChlorisCore.jl
@@ -20,6 +20,9 @@ export AbstractStateVariableSet
 
 export AMC, AIMC, AHDMC, AMCS
 
+include("check_extraneous_fields.jl")
+export check_extraneous_fields
+
 include("initialize.jl")
 export initialize, get_required_fields, validate_fields, preprocess_fields, initialize_field
 export get_dimensions

--- a/src/TethysChlorisCore.jl
+++ b/src/TethysChlorisCore.jl
@@ -24,7 +24,8 @@ include("check_extraneous_fields.jl")
 export check_extraneous_fields
 
 include("initialize.jl")
-export initialize, get_required_fields, validate_fields, preprocess_fields, initialize_field
+export initialize, validate_fields, preprocess_fields, initialize_field
+export get_optional_fields, get_calculated_fields, get_required_fields
 export get_dimensions
 
 end

--- a/src/check_extraneous_fields.jl
+++ b/src/check_extraneous_fields.jl
@@ -1,0 +1,30 @@
+"""
+    check_extraneous_fields(::Type{T}, data::Dict{String,Any}) where {T<:AbstractModelComponent}
+
+Check if the input dictionary contains any keys that are not part of the required fields for type T.
+
+# Arguments
+- `T`: Type of model component to check fields against
+- `data`: Dictionary containing fields to validate
+- `required_fields`: List of required fields for the model component. This is typically obtained from `get_required_fields(T)` or `fieldnames(T)`
+
+# Throws
+- `ArgumentError`: If any extraneous keys are found in the data dictionary
+"""
+function check_extraneous_fields(
+    ::Type{T},
+    data::Dict{String,Any},
+    required_fields::Union{Vector{String},NTuple{N,String}},
+) where {T<:AbstractModelComponent,N}
+    for key in keys(data)
+        if key ∉ required_fields
+            throw(ArgumentError("Extraneous key for type $T: $key"))
+        end
+    end
+end
+
+function check_extraneous_fields(
+    ::Type{T}, data::Dict{String,Any}
+) where {T<:AbstractModelComponent}
+    return check_extraneous_fields(T, data, String.(fieldnames(T)))
+end

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -198,7 +198,7 @@ Initialize a field array with specified dimensions and optionally set initial co
 - `default`: Optional default value to use if no initial condition is found
 
 # Returns
-- Array{FT}: Initialized array with the specified dimensions, filled with initial conditions if available
+- `Array{FT}`: Initialized array with the specified dimensions, filled with initial conditions if available
 """
 function initialize_field(
     ::Type{FT},

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -69,9 +69,43 @@ This is a default method that can be specialized for specific subtypes that need
 - `Vector{Symbol}`: A vector of symbols with the fields required to initialize the AbstractModelComponent type
 
 """
-function get_required_fields(
-    ::Type{T}
-) where {T<:Union{AbstractModelComponent,AbstractModelComponentSet}}
+function get_required_fields(::Type{T}) where {T<:AbstractModelComponent}
+    all_fields = Set(fieldnames(T))
+    optional_fields = Set(get_optional_fields(T))
+    calculated_fields = Set(get_calculated_fields(T))
+    return collect(setdiff(setdiff(all_fields, optional_fields), calculated_fields))
+end
+
+"""
+    get_optional_fields(::Type{T}) where {T<:AbstractModelComponent}
+
+Get a list of optional fields for a given model component type. Optional fields are those that can be omitted when creating
+a model component. By default, returns an empty list. Components should override this method if they have optional fields.
+
+# Arguments
+- `T`: Type of model component to get optional fields for
+
+# Returns
+- `Vector{Symbol}`: List of optional field names
+"""
+function get_optional_fields(::Type{T}) where {T<:AbstractModelComponent}
+    return Symbol[]
+end
+
+"""
+    get_calculated_fields(::Type{T}) where {T<:AbstractModelComponent}
+
+Get a list of calculated fields for a given model component type. Calculated fields are those that are computed based on
+other fields and should not be provided when creating a model component. By default, returns an empty list. Components
+should override this method if they have calculated fields.
+
+# Arguments
+- `T`: Type of model component to get calculated fields for
+
+# Returns
+- `Vector{Symbol}`: List of calculated field names
+"""
+function get_calculated_fields(::Type{T}) where {T<:AbstractModelComponent}
     return Symbol[]
 end
 
@@ -84,8 +118,10 @@ Performs some checks on the fields passed to initialize the AbstractModelCompone
 - `nothing`: If all fields are valid, the function returns nothing
 
 """
-function validate_fields(::Type{T}, data) where {T<:AbstractModelComponent}
-    return nothing
+function validate_fields(
+    ::Type{T}, data::Dict{String,Any}
+) where {T<:AbstractModelComponent}
+    return check_extraneous_fields(T, data)
 end
 
 # Default: no preprocessing

--- a/test/test-check_extraneous_fields.jl
+++ b/test/test-check_extraneous_fields.jl
@@ -1,0 +1,37 @@
+using Test
+using TethysChlorisCore
+
+FT = Float64
+struct MockComponent{FT} <: AbstractModelComponent{FT}
+    field1::FT
+    field2::FT
+    field3::FT
+end
+
+function get_optional_fields(::Type{MockComponent})
+    return [:field1]
+end
+
+function get_calculated_fields(::Type{MockComponent})
+    return [:field3]
+end
+
+@testset "check_extraneous_fields" begin
+    # Valid case - only required fields
+    data = Dict{String,Any}("field1" => 1, "field2" => 2, "field4" => 3)
+
+    @test_nowarn check_extraneous_fields(
+        MockComponent{FT}, data, ["field1", "field2", "field4"]
+    )
+    @test_nowarn check_extraneous_fields(
+        MockComponent{FT}, data, NTuple{3,String}(("field1", "field2", "field4"))
+    )
+    @test_throws MethodError check_extraneous_fields(
+        MockComponent{FT}, data, [:field1, :field2]
+    )
+    @test_throws MethodError check_extraneous_fields(
+        MockComponent{FT}, data, NTuple{2,Symbol}((:field1, :field2))
+    )
+    @test_throws ArgumentError check_extraneous_fields(MockComponent{FT}, data, ["field1"])
+    @test_throws ArgumentError check_extraneous_fields(MockComponent{FT}, data)
+end

--- a/test/test-initialize.jl
+++ b/test/test-initialize.jl
@@ -6,6 +6,24 @@ using NCDatasets
 Base.@kwdef struct TestParams{FT<:AbstractFloat} <: AbstractParameters{FT}
     required::FT
     optional::FT
+    calculated::FT
+end
+
+function TethysChlorisCore.preprocess_fields(
+    ::Type{FT}, ::Type{TestParams}, data::Dict{String,Any}
+) where {FT<:AbstractFloat}
+    # Example preprocessing: convert all values to Float64
+    processed = copy(data)
+    processed["calculated"] = processed["required"] + processed["optional"]
+    return processed
+end
+
+function TethysChlorisCore.get_optional_fields(::Type{TestParams})
+    return [:optional]
+end
+
+function TethysChlorisCore.get_calculated_fields(::Type{TestParams})
+    return [:calculated]
 end
 
 Base.@kwdef struct TestAuxVars{FT<:AbstractFloat} <: AbstractAuxiliaryVariables{FT}
@@ -13,82 +31,91 @@ Base.@kwdef struct TestAuxVars{FT<:AbstractFloat} <: AbstractAuxiliaryVariables{
     var2::Array{FT,3}
 end
 
-# Test implementations
-function TethysChlorisCore.get_required_fields(::Type{TestParams})
-    return [:required]
-end
-
 function TethysChlorisCore.get_dimensions(::Type{TestAuxVars}, data)
     return Dict("var1" => (10, 5), "var2" => (10, 5, 3))
 end
 
-@testset "Initialize Tests" begin
-    @testset "initialize" begin
-        # Test successful initialization
-        data = Dict("required" => 1.0, "optional" => 2.0)
-        comp = initialize(Float64, TestParams, data)
-        @test comp.required == 1.0
-        @test comp.optional == 2.0
+FT = Float64
 
-        # Test missing required field
-        @test_throws ArgumentError initialize(Float64, TestParams, Dict("optional" => 2.0))
+@testset "validate_fields" begin
+    # Valid case
+    valid_data = Dict{String,Any}("required" => 1, "optional" => 2)
+    @test_nowarn validate_fields(TestParams, valid_data)
 
-        # Test type mismatch
-        @test_throws ArgumentError initialize(
-            Float64, TestParams, Dict("required" => "wrong", "optional" => 2.0)
-        )
+    # Invalid case
+    invalid_data = copy(valid_data)
+    invalid_data["extraneous"] = 3
+    @test_throws ArgumentError validate_fields(TestParams, invalid_data)
+end
+
+@testset "get_required_fields" begin
+    required_fields = get_required_fields(TestParams)
+    @test required_fields == [:required]
+end
+
+@testset "initialize" begin
+    # Test successful initialization
+    data = Dict{String,Any}("required" => 1.0, "optional" => 2.0)
+    comp = initialize(Float64, TestParams, data)
+    @test comp.required == 1.0
+    @test comp.optional == 2.0
+    @test comp.calculated == 3.0
+
+    # Test missing required field
+    @test_throws ArgumentError initialize(
+        Float64, TestParams, Dict{String,Any}("optional" => 2.0)
+    )
+end
+
+@testset "get_required_fields" begin
+    @test get_required_fields(TestParams) == [:required]
+    @test get_required_fields(TestAuxVars) == Symbol[:var1, :var2]
+end
+
+@testset "validate_fields" begin
+    @test validate_fields(TestParams, Dict{String,Any}()) === nothing
+end
+
+@testset "preprocess_fields" begin
+    # Test default preprocessing
+    data = Dict("test" => 1.0)
+    @test preprocess_fields(Float64, TestParams, data) === data
+
+    # Test auxiliary variables preprocessing
+    mktempdir() do path
+        filename = joinpath(path, "test.nc")
+        ds = NCDataset(filename, "c")
+        processed = preprocess_fields(Float64, TestAuxVars, ds)
+        @test haskey(processed, "var1")
+        @test haskey(processed, "var2")
+        @test size(processed["var1"]) == (10, 5)
+        @test size(processed["var2"]) == (10, 5, 3)
+        return close(ds)
     end
+end
 
-    @testset "get_required_fields" begin
-        @test get_required_fields(TestParams) == [:required]
-        @test get_required_fields(TestAuxVars) == Symbol[]
+@testset "initialize_field" begin
+    mktempdir() do path
+        filename = joinpath(path, "test.nc")
+        ds = NCDataset(filename, "c")
+
+        # Test initialization with default
+        field = initialize_field(Float64, ds, "nonexistent", (2, 3); default=1.0)
+        @test size(field) == (2, 3)
+        @test all(field[1, :] .== 1.0)
+
+        # Test initialization without default
+        field = initialize_field(Float64, ds, "nonexistent", (2, 3))
+        @test size(field) == (2, 3)
+        @test all(field .== 0.0)
+
+        return close(ds)
     end
+end
 
-    @testset "validate_fields" begin
-        @test validate_fields(TestParams, Dict()) === nothing
-    end
-
-    @testset "preprocess_fields" begin
-        # Test default preprocessing
-        data = Dict("test" => 1.0)
-        @test preprocess_fields(Float64, TestParams, data) === data
-
-        # Test auxiliary variables preprocessing
-        mktempdir() do path
-            filename = joinpath(path, "test.nc")
-            ds = NCDataset(filename, "c")
-            processed = preprocess_fields(Float64, TestAuxVars, ds)
-            @test haskey(processed, "var1")
-            @test haskey(processed, "var2")
-            @test size(processed["var1"]) == (10, 5)
-            @test size(processed["var2"]) == (10, 5, 3)
-            return close(ds)
-        end
-    end
-
-    @testset "initialize_field" begin
-        mktempdir() do path
-            filename = joinpath(path, "test.nc")
-            ds = NCDataset(filename, "c")
-
-            # Test initialization with default
-            field = initialize_field(Float64, ds, "nonexistent", (2, 3); default=1.0)
-            @test size(field) == (2, 3)
-            @test all(field[1, :] .== 1.0)
-
-            # Test initialization without default
-            field = initialize_field(Float64, ds, "nonexistent", (2, 3))
-            @test size(field) == (2, 3)
-            @test all(field .== 0.0)
-
-            return close(ds)
-        end
-    end
-
-    @testset "get_dimensions" begin
-        @test isempty(get_dimensions(TestParams, nothing))
-        dims = get_dimensions(TestAuxVars, nothing)
-        @test dims["var1"] == (10, 5)
-        @test dims["var2"] == (10, 5, 3)
-    end
+@testset "get_dimensions" begin
+    @test isempty(get_dimensions(TestParams, nothing))
+    dims = get_dimensions(TestAuxVars, nothing)
+    @test dims["var1"] == (10, 5)
+    @test dims["var2"] == (10, 5, 3)
 end


### PR DESCRIPTION
## Summary
This PR
* adds a convenience function, `check_extraneous_fields`, used by the default `validate_fields`, to ensure that the user does not pass unused fields to the initialization function. This should help the user realize that their initialization file(s) are incorrect quicker
* adds two convenience functions, `get_optional_fields` and `get_calculated_fields` and refactor `get_required_fields`, enabling the user to only specify optional and calculated fields, as required fields will be defined as the set difference between a call to `fieldnames(T)` and the union of the optional and calculated fields. 

## Related issues

There is no related issue.


## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [X] I am following the [contributing guidelines](https://github.com/EPFL-ENAC/TethysChlorisCore.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
