### PR TITLE
build: remove Revise as leftover dep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,7 @@ version = "0.2.0"
 
 [deps]
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
 NCDatasets = "0.14"
-Revise = "3"
 julia = "1.10"


### PR DESCRIPTION
This PR simply removes Revise as leftover dependency in TethysChlorisCore

## Related issues

There is no related issue.

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/EPFL-ENAC/TethysChlorisCore.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
